### PR TITLE
Replace all foxglove references

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["plugin:@foxglove/base"],
+  extends: ["plugin:@lichtblick/base"],
   env: { node: true, es2022: true },
   parserOptions: {
     project: "tsconfig.json",
@@ -8,7 +8,7 @@ module.exports = {
   overrides: [
     {
       files: ["*.ts", "*.tsx"],
-      extends: ["plugin:@foxglove/typescript"],
+      extends: ["plugin:@lichtblick/typescript"],
       parserOptions: { project: "tsconfig.json" },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Lichtblick default eslint configuration & rules.
 
-Please err on the side of conservative changes to this repo - multiple Foxglove projects should adopt a change before making it a default.
+Please err on the side of conservative changes to this repo - multiple Lichtblick projects should adopt a change before making it a default.
 
 ## Rules
 
@@ -14,10 +14,10 @@ See [rules/README.md](rules/README.md) for details on each rule.
 
 The following configurations are available:
 
-- `plugin:@foxglove/base`
-- `plugin:@foxglove/jest`
-- `plugin:@foxglove/react`
-- `plugin:@foxglove/typescript`
+- `plugin:@lichtblick/base`
+- `plugin:@lichtblick/jest`
+- `plugin:@lichtblick/react`
+- `plugin:@lichtblick/typescript`
 
 **Typescript + React Example**
 
@@ -43,14 +43,14 @@ In your `.eslintrc.js`:
 ```js
 module.exports = {
   extends: [
-    "plugin:@foxglove/base",
-    "plugin:@foxglove/jest",
-    "plugin:@foxglove/react",
+    "plugin:@lichtblick/base",
+    "plugin:@lichtblick/jest",
+    "plugin:@lichtblick/react",
   ],
   overrides: [
     {
       files: ["*.ts", "*.tsx"],
-      extends: ["plugin:@foxglove/typescript"],
+      extends: ["plugin:@lichtblick/typescript"],
       parserOptions: {
         project: "tsconfig.json",
       },
@@ -59,7 +59,7 @@ module.exports = {
 };
 ```
 
-You can add `"plugin:@foxglove/typescript"` to the top level `extends` instead of using `overrides` if your project contains no `.js` files.
+You can add `"plugin:@lichtblick/typescript"` to the top level `extends` instead of using `overrides` if your project contains no `.js` files.
 
 ## License
 
@@ -74,6 +74,3 @@ tag=$(npm version minor) && echo "$tag"
 git push && git push origin "$tag"
 ```
 
-## Stay in touch
-
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
-  plugins: ["@foxglove", "import", "filenames", "es"],
+  plugins: ["@lichtblick", "import", "filenames", "es"],
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: "module",
@@ -35,9 +35,9 @@ module.exports = {
     "filenames/match-exported": "error",
 
     // require double equal for null and undefined, triple equal everywhere else
-    "@foxglove/strict-equality": "error",
-    "@foxglove/no-return-promise-resolve": "error",
-    "@foxglove/prefer-hash-private": "error",
+    "@lichtblick/strict-equality": "error",
+    "@lichtblick/no-return-promise-resolve": "error",
+    "@lichtblick/prefer-hash-private": "error",
 
     // require curly braces everywhere
     curly: "error",

--- a/configs/react.js
+++ b/configs/react.js
@@ -18,7 +18,7 @@ module.exports = {
     "react/jsx-no-target-blank": ["error", { allowReferrer: true }],
 
     // deprecated mui/styled in our frontend code in favor of tss-react/mui
-    "@foxglove/no-restricted-imports": [
+    "@lichtblick/no-restricted-imports": [
       "error",
       {
         name: "@mui/material",

--- a/configs/typescript.example.tsx
+++ b/configs/typescript.example.tsx
@@ -20,7 +20,7 @@ void (async () => {
   str ? 0 : 1; // allowed
   maybeStr ? 0 : 1; // allowed
   num ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions
-  num == 0 ? 0 : 1; // eslint-disable-line @foxglove/strict-equality
+  num == 0 ? 0 : 1; // eslint-disable-line @lichtblick/strict-equality
   num === 0 ? 0 : 1; // allowed
   maybeNum ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions
   maybeObj ? 0 : 1; // allowed
@@ -35,7 +35,7 @@ void undefined; // eslint-disable-line @typescript-eslint/no-meaningless-void-op
 <></>; // eslint-disable-line @typescript-eslint/no-unused-expressions
 
 class C {
-  private x = 1; // eslint-disable-line @foxglove/prefer-hash-private
+  private x = 1; // eslint-disable-line @lichtblick/prefer-hash-private
   constructor() {
     void this.x;
   }

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -10,7 +10,7 @@ module.exports = {
       "error",
       { checkNever: true },
     ],
-    "@foxglove/no-boolean-parameters": "error",
+    "@lichtblick/no-boolean-parameters": "error",
 
     // `<T>x` style assertions are not compatible with JSX code,
     // so for consistency we prefer `x as T` everywhere.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lichtblick/eslint-plugin",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lichtblick/eslint-plugin",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6",
@@ -14,8 +14,8 @@
         "typescript": "^4 || ^5"
       },
       "devDependencies": {
-        "@lichtblick/eslint-plugin": "file:.",
         "@foxglove/tsconfig": "2.0.0",
+        "@lichtblick/eslint-plugin": "file:.",
         "@types/jest": "29.5.3",
         "@typescript-eslint/eslint-plugin": "6.1.0",
         "@typescript-eslint/parser": "6.1.0",
@@ -725,10 +725,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@lichtblick/eslint-plugin": {
-      "resolved": "",
-      "link": true
-    },
     "node_modules/@foxglove/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-2.0.0.tgz",
@@ -1215,6 +1211,10 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "node_modules/@lichtblick/eslint-plugin": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6995,11 +6995,390 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw=="
     },
+    "@foxglove/tsconfig": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tifun2tMxfA0wJ4caDKnLvAm+CpNdaK2BYD78w07GdgMsoeVMu0KxAiR7ehRoR3QN6DUW7XDP5J4DqMTj3YFag==",
+      "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
+      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
+      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.6.1",
+        "@jest/reporters": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.5.0",
+        "jest-config": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-resolve-dependencies": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
+        "jest-watcher": "^29.6.1",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.6.1",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "@jest/environment": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
+        "jest-mock": "^29.6.1"
+      }
+    },
+    "@jest/expect": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.6.1",
+        "jest-snapshot": "^29.6.1"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
+      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.4.3"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.1",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
+      }
+    },
+    "@jest/globals": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "jest-mock": "^29.6.1"
+      }
+    },
+    "@jest/reporters": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
+    "@jest/source-map": {
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
+      "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      }
+    },
+    "@jest/test-result": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.6.1",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.6.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.6.1",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      }
+    },
+    "@jest/types": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.0",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
     "@lichtblick/eslint-plugin": {
       "version": "file:",
       "requires": {
-        "@lichtblick/eslint-plugin": "file:",
         "@foxglove/tsconfig": "2.0.0",
+        "@lichtblick/eslint-plugin": "file:",
         "@types/jest": "29.5.3",
         "@typescript-eslint/eslint-plugin": "6.1.0",
         "@typescript-eslint/parser": "6.1.0",
@@ -11632,385 +12011,6 @@
           "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
           "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
         }
-      }
-    },
-    "@foxglove/tsconfig": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tifun2tMxfA0wJ4caDKnLvAm+CpNdaK2BYD78w07GdgMsoeVMu0KxAiR7ehRoR3QN6DUW7XDP5J4DqMTj3YFag==",
-      "dev": true
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-      "requires": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
-      }
-    },
-    "@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
-    },
-    "@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        }
-      }
-    },
-    "@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true
-    },
-    "@jest/console": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
-      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^29.6.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "slash": "^3.0.0"
-      }
-    },
-    "@jest/core": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
-      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
-      "dev": true,
-      "requires": {
-        "@jest/console": "^29.6.1",
-        "@jest/reporters": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
-        "@jest/types": "^29.6.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.1",
-        "jest-haste-map": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-resolve-dependencies": "^29.6.1",
-        "jest-runner": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
-        "jest-watcher": "^29.6.1",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "@jest/environment": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
-      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
-      "dev": true,
-      "requires": {
-        "@jest/fake-timers": "^29.6.1",
-        "@jest/types": "^29.6.1",
-        "@types/node": "*",
-        "jest-mock": "^29.6.1"
-      }
-    },
-    "@jest/expect": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
-      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
-      "dev": true,
-      "requires": {
-        "expect": "^29.6.1",
-        "jest-snapshot": "^29.6.1"
-      }
-    },
-    "@jest/expect-utils": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
-      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
-      "dev": true,
-      "requires": {
-        "jest-get-type": "^29.4.3"
-      }
-    },
-    "@jest/fake-timers": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
-      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^29.6.1",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
-        "jest-message-util": "^29.6.1",
-        "jest-mock": "^29.6.1",
-        "jest-util": "^29.6.1"
-      }
-    },
-    "@jest/globals": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
-      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^29.6.1",
-        "@jest/expect": "^29.6.1",
-        "@jest/types": "^29.6.1",
-        "jest-mock": "^29.6.1"
-      }
-    },
-    "@jest/reporters": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
-      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
-      "dev": true,
-      "requires": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
-        "@jest/types": "^29.6.1",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      }
-    },
-    "@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
-      "dev": true,
-      "requires": {
-        "@sinclair/typebox": "^0.27.8"
-      }
-    },
-    "@jest/source-map": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
-      "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      }
-    },
-    "@jest/test-result": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
-      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
-      "dev": true,
-      "requires": {
-        "@jest/console": "^29.6.1",
-        "@jest/types": "^29.6.1",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      }
-    },
-    "@jest/test-sequencer": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
-      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
-      "dev": true,
-      "requires": {
-        "@jest/test-result": "^29.6.1",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
-        "slash": "^3.0.0"
-      }
-    },
-    "@jest/transform": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.1",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      }
-    },
-    "@jest/types": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
-      "dev": true,
-      "requires": {
-        "@jest/schemas": "^29.6.0",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      }
-    },
-    "@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@nodelib/fs.scandir": {

--- a/rules/README.md
+++ b/rules/README.md
@@ -4,7 +4,7 @@ The following rules are provided by `@lichtblick/eslint-plugin`. You may need to
 
 **Key:** 🔧 = fixable, 💡 = has suggestions, 💭 = requires type information (TypeScript only)
 
-### [`@foxglove/no-boolean-parameters`](./no-boolean-parameters.js) 💭 🔧
+### [`@lichtblick/no-boolean-parameters`](./no-boolean-parameters.js) 💭 🔧
 
 Prohibit boolean parameters to functions, including optional parameters and default values.
 
@@ -34,13 +34,13 @@ This rule accepts a single object option with the following default configuratio
 
 ```json
 {
-  "@foxglove/no-boolean-parameters": ["error", { "allowLoneParameter": false }]
+  "@lichtblick/no-boolean-parameters": ["error", { "allowLoneParameter": false }]
 }
 ```
 
 - `allowLoneParameter: true` will not report an error if a boolean parameter is the **only** parameter to a function.
 
-### [`@foxglove/no-return-promise-resolve`](./no-return-promise-resolve.js) 🔧
+### [`@lichtblick/no-return-promise-resolve`](./no-return-promise-resolve.js) 🔧
 
 Disallow returning `Promise.resolve(...)` or `Promise.reject(...)` inside an async function. This is redundant since an async function will always return a Promise — use `return` or `throw` directly instead.
 
@@ -72,7 +72,7 @@ async () => {
 };
 ```
 
-### [`@foxglove/prefer-hash-private`](./prefer-hash-private.js) 💡
+### [`@lichtblick/prefer-hash-private`](./prefer-hash-private.js) 💡
 
 Prefer using [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) instead of the TypeScript `private` keyword. In contrast with `private x`, which is a compile-time-only feature of TypeScript, `#x` is _truly_ private (cannot be accessed at runtime from outside the class using subscript notation) and cannot accidentally interfere with superclass properties.
 

--- a/rules/no-restricted-imports.js
+++ b/rules/no-restricted-imports.js
@@ -2,7 +2,7 @@ const builtinRules = require("eslint/use-at-your-own-risk").builtinRules;
 
 /**
  * Re-export the `no-restricted-imports` rules so that we can use them as
- * `@foxglove/no-restricted-imports` instead of `no-restricted-imports`.
+ * `@lichtblick/no-restricted-imports` instead of `no-restricted-imports`.
  *
  * This is to make accidental overrides more difficult. Without this any local
  * eslint config that defines its own `no-restricted-imports` rule will ignore

--- a/rules/strict-equality.js
+++ b/rules/strict-equality.js
@@ -2,7 +2,7 @@
 function isNullLiteral(node) {
   return (
     node.type === "Literal" &&
-    // eslint-disable-next-line @foxglove/strict-equality
+    // eslint-disable-next-line @lichtblick/strict-equality
     node.value === null &&
     !node.regex &&
     !node.bigint


### PR DESCRIPTION
Replace all references to Foxglove with Lichtblick.

It has to be changed in the Lichtblick Suite as well, to match the eslint's rules names.